### PR TITLE
fix: If the delta was missing the path a generic error was logged

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function(app) {
               let newValues = []
               update.values.forEach(pathValue => {
                 props.mappings.forEach(mapping => {
-                  if ( pathValue.path.startsWith(mapping.path) ) {
+                  if ( pathValue.path && pathValue.path.startsWith(mapping.path) ) {
                     const newPath = mapping.newPath
                       + pathValue.path.slice(mapping.path.length, pathValue.path.length)
                     app.debug('mapping to %s to %s', pathValue.path, newPath)
@@ -46,7 +46,7 @@ module.exports = function(app) {
     unsubscribes.forEach(f => f())
     unsubscribes = []
   }
-  
+
   plugin.id = "signalk-path-mapper"
   plugin.name = "Path Mapper"
   plugin.description = "SignalK Node Server Plugin that maps the paths of incoming Signal K deltas to different paths"


### PR DESCRIPTION
 If the delta was missing the path the following error was logged: Cannot read property 'startsWith' of undefined

Now if the path is missing path-mapper will ignore it and
Sk Specification can log a detailed error about it.