### PR TITLE
fix: similar paths are broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,10 @@ module.exports = function(app) {
   function mapKPs(mappings, kps, key, source) {
     kps.forEach(pathValue => {
       mappings.forEach(mapping => {
+        let mapLength = mapping.path.split(".").length
         if (
           pathValue.path
-            && pathValue.path.startsWith(mapping.path)
+            && (pathValue.path.split(".").slice(0,mapLength).join(".") === mapping.path)
             && (!mapping.source || mapping.source == source)
         ) {
           const newPath = mapping.newPath
@@ -71,7 +72,7 @@ module.exports = function(app) {
     unsubscribes.forEach(f => f())
     unsubscribes = []
   }
-  
+
   plugin.id = "signalk-path-mapper"
   plugin.name = "Path Mapper"
   plugin.description = "SignalK Node Server Plugin that maps the paths of incoming Signal K deltas to different paths"

--- a/index.js
+++ b/index.js
@@ -20,10 +20,9 @@ module.exports = function(app) {
   function mapKPs(mappings, kps, key, source) {
     kps.forEach(pathValue => {
       mappings.forEach(mapping => {
-        let mapLength = mapping.path.split(".").length
         if (
           pathValue.path
-            && (pathValue.path.split(".").slice(0,mapLength).join(".") === mapping.path)
+            && (pathValue.path + '.').startsWith(mapping.path + '.')
             && (!mapping.source || mapping.source == source)
         ) {
           const newPath = mapping.newPath


### PR DESCRIPTION
There was an issue with startsWith because it cannot tell the difference between similar paths.

For example electrical.switches.bank.25.1 and electrical.switches.bank.25.10 look the same to startsWith.

The new behaviour is to split the path and compare to the mapping.